### PR TITLE
fix: add missing assert to 'test_can_reach_api'

### DIFF
--- a/01_our_microservice/customerdataapi/tests/test_views.py
+++ b/01_our_microservice/customerdataapi/tests/test_views.py
@@ -5,6 +5,7 @@ Testing the django rest framework configuration
 from django.test import TestCase
 from rest_framework.test import APIClient
 
+
 class CustomerDataAPITestCase(TestCase):
     """
     Basic test case that asserts that we can actually call the API
@@ -15,4 +16,6 @@ class CustomerDataAPITestCase(TestCase):
         Asserts that calling the API actually works
         """
         client = APIClient()
-        client.post('/api/v1/customerdata/', {'id': '1234'}, format='json')
+        response = client.get("/api/v1/customerdata/")
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# Description

This Pull Request is solving this small challenge:

> In the `customerdataapi` test suite, the `test_can_reach_api`is not really useful. 
Can you tell us why and propose a change in a different PR to make it better?
> 

The problem with the "test_can_reach_api" is that it will never fail because it is not using asserts.
### Solution and improvements implemented in this PR:
- Add an assert.
- To know if the API can be called, it will be enough to send a GET request and expect a 200 OK.


## Testing instructions

1. Pull this branch to your local environment.
2. Run these commands once you are in the folder `01_our_microservice`:
```BASH
python -m venv venv
source venv/bin/activate
pip install pip==21.2
make requirements 
make test
```
